### PR TITLE
Bump cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "http://doc.servo.org/app_units/"


### PR DESCRIPTION
This is necessary so we can use the new version in Servo.
