### PR TITLE
Implement num_traits::Zero for Au.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,13 +9,13 @@ license = "MPL-2.0"
 
 [features]
 default = []
-plugins = ["heapsize", "heapsize_plugin", "serde", "serde_macros", "euclid/plugins"]
+plugins = ["heapsize", "heapsize_plugin", "serde", "serde_macros"]
 
 [dependencies]
 serde = {version = ">=0.6, <0.8", optional = true}
 serde_macros = {version = ">=0.6, <0.8", optional = true}
 rustc-serialize = "0.3"
-euclid = "0.6.2"
+num-traits = "0.1.32"
 
 [dependencies.heapsize]
 version = ">=0.2.2, <0.4"

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-use euclid::num::Zero;
+use num_traits::Zero;
 use rustc_serialize::{Encodable, Encoder};
 use std::default::Default;
 use std::fmt;
@@ -27,6 +27,11 @@ impl Zero for Au {
     #[inline]
     fn zero() -> Au {
         Au(0)
+    }
+
+    #[inline]
+    fn is_zero(&self) -> bool {
+        self.0 == 0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,9 @@
 #![cfg_attr(feature = "plugins", plugin(serde_macros))]
 #![cfg_attr(feature = "plugins", plugin(heapsize_plugin))]
 
-extern crate euclid;
 #[cfg(feature = "plugins")]
 extern crate heapsize;
+extern crate num_traits;
 extern crate rustc_serialize;
 #[cfg(feature = "plugins")]
 extern crate serde;


### PR DESCRIPTION
euclid already has a blanket implementation of its Zero trait for types that
implement num_traits::Zero, which ensures that euclid::num::Zero remains
implemented for Au.
