### PR TITLE
Use 1<<30 - 1 for max/min values to avoid overflow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "http://doc.servo.org/app_units/"

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -59,10 +59,10 @@ impl Zero for Au {
     }
 }
 
-// 1 << 30 lets us add/subtract two Au and check for overflow
+// (1 << 30) - 1 lets us add/subtract two Au and check for overflow
 // after the operation. Gecko uses the same min/max values
-pub const MAX_AU: Au = Au(1 << 30);
-pub const MIN_AU: Au = Au(- (1 << 30));
+pub const MAX_AU: Au = Au((1 << 30) - 1);
+pub const MIN_AU: Au = Au(- ((1 << 30) - 1));
 
 impl Encodable for Au {
     fn encode<S: Encoder>(&self, e: &mut S) -> Result<(), S::Error> {


### PR DESCRIPTION
`(1<<30) + (1<<30)` will overflow an `i32`, but no other combination of
valid Au values will.