### PR TITLE
Explicitly invoke `Au::clamp()` to avoid colliding with the unstable Rust library method of the same name.

### DIFF
--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -189,7 +189,7 @@ impl Au {
 
     #[inline]
     fn clamp_self(&mut self) {
-        *self = self.clamp()
+        *self = Au::clamp(*self)
     }
 
     #[inline]


### PR DESCRIPTION
Fixes breakage from rust-lang/rust#44095.

r? @Manishearth 