### PR TITLE
Make links in documentation work with commonmark

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 
 //! An Au is an "App Unit" and represents 1/60th of a CSS pixel. It was
 //! originally proposed in 2002 as a standard unit of measure in Gecko.
-//! See https://bugzilla.mozilla.org/show_bug.cgi?id=177805 for more info.
+//! See <https://bugzilla.mozilla.org/show_bug.cgi?id=177805> for more info.
 
 extern crate heapsize;
 extern crate num_traits;


### PR DESCRIPTION
This fixes formatting problems when the Markdown processor is switched to pulldown-cmark (rust-lang/rust#44229).