### PR TITLE
Use backticks in doc comments more.

### DIFF
--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -15,10 +15,10 @@ pub const AU_PER_PX: i32 = 60;
 
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Eq, Ord)]
 /// An App Unit, the fundamental unit of length in Servo. Usually
-/// 1/60th of a pixel (see AU_PER_PX)
+/// 1/60th of a pixel (see `AU_PER_PX`)
 ///
-/// Please ensure that the values are between MIN_AU and MAX_AU.
-/// It is safe to construct invalid Au values, but it may lead to
+/// Please ensure that the values are between `MIN_AU` and `MAX_AU`.
+/// It is safe to construct invalid `Au` values, but it may lead to
 /// panics and overflows.
 pub struct Au(pub i32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-//! An Au is an "App Unit" and represents 1/60th of a CSS pixel. It was
+//! An `Au` is an "App Unit" and represents 1/60th of a CSS pixel. It was
 //! originally proposed in 2002 as a standard unit of measure in Gecko.
 //! See <https://bugzilla.mozilla.org/show_bug.cgi?id=177805> for more info.
 


### PR DESCRIPTION
This fixes a couple of clippy warnings.