### PR TITLE
Make serde and num-traits dependencies optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 language: rust
+
 notifications:
   webhooks: http://build.servo.org:54856/travis
+
+cache: cargo
+
+script:
+  - cargo clean
+  - cargo check
+  - cargo test
+  - cargo check --no-default-features
+  - cargo check --features="serde_serialization"
+  - cargo check --features="num_traits"
 
 rust:
   - stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,10 @@ repository = "https://github.com/servo/app_units"
 license = "MPL-2.0"
 
 [dependencies]
-num-traits = "0.2"
-serde = "1.0"
+num-traits = { version = "0.2", optional = true }
+serde = { version = "1.0", optional = true }
+
+[features]
+default = ["num_traits", "serde_serialization"]
+num_traits = ["num-traits"]
+serde_serialization = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -2,8 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+ #[cfg(feature = "num_traits")]
 use num_traits::Zero;
+#[cfg(feature = "serde_serialization")]
 use serde::de::{Deserialize, Deserializer};
+#[cfg(feature = "serde_serialization")]
 use serde::ser::{Serialize, Serializer};
 use std::default::Default;
 use std::fmt;
@@ -22,12 +25,14 @@ pub const AU_PER_PX: i32 = 60;
 /// panics and overflows.
 pub struct Au(pub i32);
 
+ #[cfg(feature = "serde_serialization")]
 impl<'de> Deserialize<'de> for Au {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Au, D::Error> {
         Ok(Au(try!(i32::deserialize(deserializer))).clamp())
     }
 }
 
+#[cfg(feature = "serde_serialization")]
 impl Serialize for Au {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.0.serialize(serializer)
@@ -41,6 +46,7 @@ impl Default for Au {
     }
 }
 
+#[cfg(feature = "num_traits")]
 impl Zero for Au {
     #[inline]
     fn zero() -> Au {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@
 //! originally proposed in 2002 as a standard unit of measure in Gecko.
 //! See <https://bugzilla.mozilla.org/show_bug.cgi?id=177805> for more info.
 
+#[cfg(feature = "num_traits")]
 extern crate num_traits;
+#[cfg(feature = "serde_serialization")]
 extern crate serde;
 
 mod app_unit;


### PR DESCRIPTION
num-traits is only used for num_traits::Zero, which isn't used in webrender, probably only in servo. For webrender it can be turned off to reduce dependencies, besides - all it does is to construct an Au(0).

serde is also not needed in webrender, only for debugging, so that can be turned off, too. For backwards compatibility these features are turned **on** by default, in order to not break any application in the upgrade process. Also added testing for the features in isolation to the .travis.yml

Preparation for https://github.com/servo/webrender/issues/3045