### PR TITLE
Refactor and update app_units for 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies]
 num-traits = { version = "0.2", optional = true }
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [features]
 default = ["num_traits", "serde_serialization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"
 repository = "https://github.com/servo/app_units"
 license = "MPL-2.0"
+edition = "2021"
 
 [dependencies]
 num-traits = { version = "0.2", optional = true }

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -2,16 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- #[cfg(feature = "num_traits")]
+#[cfg(feature = "num_traits")]
 use num_traits::Zero;
 #[cfg(feature = "serde_serialization")]
-use serde::de::{Deserialize, Deserializer};
-#[cfg(feature = "serde_serialization")]
-use serde::ser::{Serialize, Serializer};
-use std::default::Default;
-use std::fmt;
-use std::i32;
-use std::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign};
+use serde::{ser::{Serialize, Serializer}, de::{Deserialize, Deserializer}};
+
+use std::{fmt, i32, default::Default, ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign}};
 
 /// The number of app units in a pixel.
 pub const AU_PER_PX: i32 = 60;
@@ -28,7 +24,7 @@ pub struct Au(pub i32);
  #[cfg(feature = "serde_serialization")]
 impl<'de> Deserialize<'de> for Au {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Au, D::Error> {
-        Ok(Au(try!(i32::deserialize(deserializer))).clamp())
+        Ok(Au(i32::deserialize(deserializer)?).clamp())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,11 +6,6 @@
 //! originally proposed in 2002 as a standard unit of measure in Gecko.
 //! See <https://bugzilla.mozilla.org/show_bug.cgi?id=177805> for more info.
 
-#[cfg(feature = "num_traits")]
-extern crate num_traits;
-#[cfg(feature = "serde_serialization")]
-extern crate serde;
-
 mod app_unit;
 
 pub use app_unit::{Au, MIN_AU, MAX_AU, AU_PER_PX};


### PR DESCRIPTION
Don't know how I got here but it is what it is.
I compared serde-derive `Serialize` to the current impl with `time cargo build`, doesn't make much of a difference, but might be bad for some reason? `Serialize` doesn't do anything special so I think deriving it is better.

What should I bump the version to, if approved?