### PR TITLE
Serialization fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 num-traits = { version = "0.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
+[dev-dependencies]
+ron = "0.8.0"
+
 [features]
 default = ["num_traits", "serde_serialization"]
 num_traits = ["num-traits"]

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -21,7 +21,7 @@ pub const MAX_AU: Au = Au((1 << 30) - 1);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Hash, PartialEq, PartialOrd, Eq, Ord, Default)]
-#[cfg_attr(feature = "serde_serialization", derive(Serialize))]
+#[cfg_attr(feature = "serde_serialization", derive(Serialize), serde(transparent))]
 /// An App Unit, the fundamental unit of length in Servo. Usually
 /// 1/60th of a pixel (see `AU_PER_PX`)
 ///

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -383,3 +383,10 @@ fn convert() {
     assert_eq!(Au::from_f64_px(6.12), Au(367));
     assert_eq!(Au::from_f64_px(6.13), Au(368));
 }
+
+#[cfg(feature ="serde_serialization")]
+#[test]
+fn serialize() {
+    let serialized = ron::to_string(&Au(42)).unwrap();
+    assert_eq!(ron::from_str(&serialized), Ok(Au(42)));
+}


### PR DESCRIPTION
Au's deserializer expects an i32 directly however the serializer does not (always) skip the wrapping newtype. At least Ron serializes 'Au(1)' as '(1)'  and fails to deserialize it because it expects '1'.
