### PR TITLE
Implement `Sum` and release a new version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -8,6 +8,7 @@ use num_traits::Zero;
 use serde::{Serialize, Deserialize, Deserializer};
 
 use std::{fmt, i32, default::Default, ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign}};
+use std::iter::Sum;
 
 /// The number of app units in a pixel.
 pub const AU_PER_PX: i32 = 60;
@@ -175,6 +176,12 @@ impl DivAssign<i32> for Au {
     #[inline]
     fn div_assign(&mut self, other: i32) {
         *self = (*self / other).clamp();
+    }
+}
+
+impl<'a> Sum<&'a Self> for Au {
+    fn sum<I: Iterator<Item = &'a Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |a, b| a + *b)
     }
 }
 


### PR DESCRIPTION
This change implements the `Sum` traits so that iterators of `Au` can be
summed. We would like to do this in Servo. In addition, it also prepares
for a new release of the crate, so this can be used.
