### PR TITLE
Add a `Sum` implementation for `Au`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -185,6 +185,12 @@ impl<'a> Sum<&'a Self> for Au {
     }
 }
 
+impl<'a> Sum<Self> for Au {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::zero(), |a, b| a + b)
+    }
+}
+
 impl Au {
     /// FIXME(pcwalton): Workaround for lack of cross crate inlining of newtype structs!
     #[inline]


### PR DESCRIPTION
My previous change only added an implementation of sum for `&Au`, but
this isn't always good enough when you are dealing with `into_iter()`.
