### PR TITLE
Implement `ToPrimitive` and `NumCast` traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ num-traits = { version = "0.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
+euclid = "0.22.11"
 ron = "0.8.0"
 
 [features]

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -290,9 +290,10 @@ impl Au {
 }
 
 #[cfg(feature = "num_traits")]
+// Note:
+//   - Conversions to isize and i128 are done implicitly based on the i64 impl
+//   - Conversions to other uint types are done implicitly based on the u64 impl
 impl num_traits::ToPrimitive for Au {
-    // Float conversions
-
     #[inline]
     fn to_f32(&self) -> Option<f32> {
         Some(self.to_f32_px())
@@ -302,8 +303,6 @@ impl num_traits::ToPrimitive for Au {
     fn to_f64(&self) -> Option<f64> {
         Some(self.to_f64_px())
     }
-
-    // Signed int conversions
 
     #[inline]
     fn to_i8(&self) -> Option<i8> {
@@ -326,44 +325,7 @@ impl num_traits::ToPrimitive for Au {
     }
 
     #[inline]
-    fn to_i128(&self) -> Option<i128> {
-        Some(self.to_px() as i128)
-    }
-
-    #[inline]
-    fn to_isize(&self) -> Option<isize> {
-        Some(self.to_px() as isize)
-    }
-
-    // Unsigned int conversions
-
-    #[inline]
-    fn to_u8(&self) -> Option<u8> {
-        None
-    }
-
-    #[inline]
-    fn to_u16(&self) -> Option<u16> {
-        None
-    }
-
-    #[inline]
-    fn to_u32(&self) -> Option<u32> {
-        None
-    }
-
-    #[inline]
     fn to_u64(&self) -> Option<u64> {
-        None
-    }
-
-    #[inline]
-    fn to_u128(&self) -> Option<u128> {
-        None
-    }
-
-    #[inline]
-    fn to_usize(&self) -> Option<usize> {
         None
     }
 }

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -289,6 +289,92 @@ impl Au {
     }
 }
 
+#[cfg(feature = "num_traits")]
+impl num_traits::ToPrimitive for Au {
+    // Float conversions
+
+    #[inline]
+    fn to_f32(&self) -> Option<f32> {
+        Some(self.to_f32_px())
+    }
+
+    #[inline]
+    fn to_f64(&self) -> Option<f64> {
+        Some(self.to_f64_px())
+    }
+
+    // Signed int conversions
+
+    #[inline]
+    fn to_i8(&self) -> Option<i8> {
+        None
+    }
+
+    #[inline]
+    fn to_i16(&self) -> Option<i16> {
+        None
+    }
+
+    #[inline]
+    fn to_i32(&self) -> Option<i32> {
+        Some(self.to_px())
+    }
+
+    #[inline]
+    fn to_i64(&self) -> Option<i64> {
+        Some(self.to_px() as i64)
+    }
+
+    #[inline]
+    fn to_i128(&self) -> Option<i128> {
+        Some(self.to_px() as i128)
+    }
+
+    #[inline]
+    fn to_isize(&self) -> Option<isize> {
+        Some(self.to_px() as isize)
+    }
+
+    // Unsigned int conversions
+
+    #[inline]
+    fn to_u8(&self) -> Option<u8> {
+        None
+    }
+
+    #[inline]
+    fn to_u16(&self) -> Option<u16> {
+        None
+    }
+
+    #[inline]
+    fn to_u32(&self) -> Option<u32> {
+        None
+    }
+
+    #[inline]
+    fn to_u64(&self) -> Option<u64> {
+        None
+    }
+
+    #[inline]
+    fn to_u128(&self) -> Option<u128> {
+        None
+    }
+
+    #[inline]
+    fn to_usize(&self) -> Option<usize> {
+        None
+    }
+}
+
+#[cfg(feature = "num_traits")]
+impl num_traits::NumCast for Au {
+    fn from<T: num_traits::ToPrimitive>(n: T) -> Option<Self> {
+        n.to_f64().map(Self::from_f64_px)
+    }
+}
+
 #[test]
 fn create() {
     assert_eq!(Au::zero(), Au(0));

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -539,3 +539,27 @@ fn serialize() {
     let serialized = ron::to_string(&Au(42)).unwrap();
     assert_eq!(ron::from_str(&serialized), Ok(Au(42)));
 }
+
+#[cfg(feature = "num_traits")]
+#[test]
+fn euclid_cast_au_to_f32() {
+    use euclid::default::Size2D;
+    let size_au: Size2D<Au> = Size2D::new(Au::new(20), Au::new(30));
+    let size_f32_manual: Size2D<f32> =
+        Size2D::new(Au::new(20).to_f32_px(), Au::new(30).to_f32_px());
+    let size_f32_cast: Size2D<f32> = size_au.cast();
+
+    assert_eq!(size_f32_manual, size_f32_cast);
+}
+
+#[cfg(feature = "num_traits")]
+#[test]
+fn euclid_cast_f32_to_au() {
+    use euclid::default::Size2D;
+    let size_f32: Size2D<f32> = Size2D::new(3.1456, 245.043656);
+    let size_au_manual: Size2D<Au> =
+        Size2D::new(Au::from_f32_px(3.1456), Au::from_f32_px(245.043656));
+    let size_au_cast: Size2D<Au> = size_f32.cast();
+
+    assert_eq!(size_au_manual, size_au_cast);
+}

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -504,11 +504,49 @@ fn serialize() {
 
 #[cfg(feature = "num_traits")]
 #[test]
+fn cast_au_u64() {
+    let val: Au = Au::new(120);
+    let cast: Option<u64> = num_traits::NumCast::from(val);
+    assert_eq!(cast, None)
+}
+
+#[cfg(feature = "num_traits")]
+#[test]
+fn cast_au_i16() {
+    let val: Au = Au::new(120);
+    let cast: Option<i16> = num_traits::NumCast::from(val);
+    assert_eq!(cast, None)
+}
+
+#[cfg(feature = "num_traits")]
+#[test]
+fn cast_au_i64() {
+    let val: Au = Au::new(120);
+    let cast: Option<i64> = num_traits::NumCast::from(val);
+    assert_eq!(cast, Some(2))
+}
+
+#[test]
+fn cast_au_f32() {
+    let val: Au = Au::new(120);
+    let cast: Option<f32> = num_traits::NumCast::from(val);
+    assert_eq!(cast, Some(2.0))
+}
+
+#[cfg(feature = "num_traits")]
+#[test]
+fn cast_au_f64() {
+    let val: Au = Au::new(120);
+    let cast: Option<f64> = num_traits::NumCast::from(val);
+    assert_eq!(cast, Some(2.0))
+}
+
+#[cfg(feature = "num_traits")]
+#[test]
 fn euclid_cast_au_to_f32() {
     use euclid::default::Size2D;
-    let size_au: Size2D<Au> = Size2D::new(Au::new(20), Au::new(30));
-    let size_f32_manual: Size2D<f32> =
-        Size2D::new(Au::new(20).to_f32_px(), Au::new(30).to_f32_px());
+    let size_au: Size2D<Au> = Size2D::new(Au::new(20 * 60), Au::new(30 * 60));
+    let size_f32_manual: Size2D<f32> = Size2D::new(20.0, 30.0);
     let size_f32_cast: Size2D<f32> = size_au.cast();
 
     assert_eq!(size_f32_manual, size_f32_cast);


### PR DESCRIPTION
This hooks `Au` into `euclid`s type casting mechanism and will allow us to convert code like:

```rust
let new_viewport_size = Size2D::new(
    Au::from_f32_px(window_size_data.initial_viewport.width),
    Au::from_f32_px(window_size_data.initial_viewport.height),
);
```
into
```rust
let new_viewport_size = window_size_data.initial_viewport.cast::<Au>();
```