### PR TITLE
Fix clippy lints

### DIFF
--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::iter::Sum;
 use std::{
     default::Default,
-    fmt, i32,
+    fmt,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, Sub, SubAssign},
 };
 


### PR DESCRIPTION
Methods are now defined directly on the `i32` primitive type, so the module import is unnecesary.