### PR TITLE
Implement `MallocSizeOf` for Au

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app_units"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["The Servo Project Developers"]
 description = "Servo app units type (Au)"
 documentation = "https://docs.rs/app_units/"
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 num-traits = { version = "0.2", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+malloc_size_of = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 ron = "0.8.0"
@@ -19,3 +20,4 @@ ron = "0.8.0"
 default = ["num_traits", "serde_serialization"]
 num_traits = ["num-traits"]
 serde_serialization = ["serde"]
+malloc_size_of = ["dep:malloc_size_of"]

--- a/src/app_unit.rs
+++ b/src/app_unit.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(feature = "malloc_size_of")]
+use malloc_size_of::malloc_size_of_is_0;
 #[cfg(feature = "num_traits")]
 use num_traits::Zero;
 #[cfg(feature = "serde_serialization")]
@@ -39,6 +41,9 @@ impl fmt::Debug for Au {
         write!(f, "{}px", self.to_f64_px())
     }
 }
+
+#[cfg(feature = "malloc_size_of")]
+malloc_size_of_is_0!(Au);
 
 #[cfg(feature = "serde_serialization")]
 impl<'de> Deserialize<'de> for Au {


### PR DESCRIPTION
Now that [malloc_size_of](https://github.com/servo/malloc_size_of) is published to crates.io we are moving the trait implementations of [MallocSizeOf](https://docs.rs/malloc_size_of/latest/malloc_size_of/trait.MallocSizeOf.html) and related traits into the crates that define the types. This will avoid the situation where depending on `malloc_size_of` pulls in a large number of dependencies.

This PR adds the implementation of `MallocSizeOf` to the `app_units` crate.